### PR TITLE
XCode 7 (Swift 2.0) 対応

### DIFF
--- a/DemoApp/Info.plist
+++ b/DemoApp/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>
-	<string>-.$(PRODUCT_NAME:rfc1034identifier)</string>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/UnitTests/Info.plist
+++ b/UnitTests/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>
-	<string>-.$(PRODUCT_NAME:rfc1034identifier)</string>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/UnitTests/LprojFileTests.swift
+++ b/UnitTests/LprojFileTests.swift
@@ -8,7 +8,7 @@ class LprojFileTests: XCTestCase {
         super.setUp()
 
         let path = NSFileManager.defaultManager().currentDirectoryPath.stringByAppendingPathComponent("DemoApp/Base.lproj")
-        let URL = NSURL(fileURLWithPath: path)!
+        let URL = NSURL(fileURLWithPath: path)
         lprojFile = LprojFile(URL: URL)
     }
 

--- a/UnitTests/LprojFileTests.swift
+++ b/UnitTests/LprojFileTests.swift
@@ -7,8 +7,12 @@ class LprojFileTests: XCTestCase {
     override func setUp() {
         super.setUp()
 
-        let path = NSFileManager.defaultManager().currentDirectoryPath.stringByAppendingPathComponent("DemoApp/Base.lproj")
-        let URL = NSURL(fileURLWithPath: path)
+        let cwd = NSProcessInfo.processInfo().environment["MY_SOURCE_ROOT"]
+        let fileManager = NSFileManager()
+        fileManager.changeCurrentDirectoryPath(cwd!)
+
+        let path = NSFileManager.defaultManager().currentDirectoryPath
+        let URL = NSURL(fileURLWithPath: path).URLByAppendingPathComponent("DemoApp/Base.lproj")
         lprojFile = LprojFile(URL: URL)
     }
 

--- a/UnitTests/StringsFileTests.swift
+++ b/UnitTests/StringsFileTests.swift
@@ -9,7 +9,7 @@ class StringsFileTests: XCTestCase {
         super.setUp()
 
         let directoryPath = NSFileManager.defaultManager().currentDirectoryPath.stringByAppendingPathComponent("DemoApp")
-        let directoryURL = NSURL(fileURLWithPath: directoryPath)!
+        let directoryURL = NSURL(fileURLWithPath: directoryPath)
         localizableStringsFile = StringsFile(URL: directoryURL.URLByAppendingPathComponent("en.lproj/Localizable.strings"))
         xibStringsFile = StringsFile(URL: directoryURL.URLByAppendingPathComponent("en.lproj/Main.strings"))
     }

--- a/UnitTests/StringsFileTests.swift
+++ b/UnitTests/StringsFileTests.swift
@@ -7,9 +7,13 @@ class StringsFileTests: XCTestCase {
 
     override func setUp() {
         super.setUp()
+        
+        let cwd = NSProcessInfo.processInfo().environment["MY_SOURCE_ROOT"]
+        let fileManager = NSFileManager()
+        fileManager.changeCurrentDirectoryPath(cwd!)
 
-        let directoryPath = NSFileManager.defaultManager().currentDirectoryPath.stringByAppendingPathComponent("DemoApp")
-        let directoryURL = NSURL(fileURLWithPath: directoryPath)
+        let directoryPath = NSFileManager.defaultManager().currentDirectoryPath
+        let directoryURL = NSURL(fileURLWithPath: directoryPath).URLByAppendingPathComponent("DemoApp")
         localizableStringsFile = StringsFile(URL: directoryURL.URLByAppendingPathComponent("en.lproj/Localizable.strings"))
         xibStringsFile = StringsFile(URL: directoryURL.URLByAppendingPathComponent("en.lproj/Main.strings"))
     }

--- a/UnitTests/TargetTests.swift
+++ b/UnitTests/TargetTests.swift
@@ -6,6 +6,11 @@ class TargetTests: XCTestCase {
 
     override func setUp() {
         super.setUp()
+        
+        let cwd = NSProcessInfo.processInfo().environment["MY_SOURCE_ROOT"]
+        let fileManager = NSFileManager()
+        fileManager.changeCurrentDirectoryPath(cwd!)
+        
         target = Target(path: "DemoApp")
     }
 

--- a/circle.yml
+++ b/circle.yml
@@ -1,9 +1,12 @@
 machine:
+  xcode:
+    version: 7.0
   environment:
-    LC_CTYPE: en_US.UTF-8
+    LANG: en_US.UTF-8
 
 dependencies:
-  override:
+  pre:
+    - brew uninstall xctool && brew install --HEAD xctool
     - sudo gem install xcpretty
 
 test:

--- a/ls2xs.xcodeproj/project.pbxproj
+++ b/ls2xs.xcodeproj/project.pbxproj
@@ -214,6 +214,8 @@
 		7F9ABCCC1A88E79100ACB4B9 /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
+				LastSwiftMigration = 0700;
+				LastSwiftUpdateCheck = 0700;
 				LastUpgradeCheck = 0610;
 				ORGANIZATIONNAME = "Yosuke Ishikawa";
 				TargetAttributes = {

--- a/ls2xs.xcodeproj/project.pbxproj
+++ b/ls2xs.xcodeproj/project.pbxproj
@@ -216,7 +216,7 @@
 			attributes = {
 				LastSwiftMigration = 0700;
 				LastSwiftUpdateCheck = 0700;
-				LastUpgradeCheck = 0610;
+				LastUpgradeCheck = 0700;
 				ORGANIZATIONNAME = "Yosuke Ishikawa";
 				TargetAttributes = {
 					7F9751311A89C90D005E27F8 = {
@@ -359,6 +359,7 @@
 				INFOPLIST_FILE = DemoApp/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 8.3;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "-.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
 			};
@@ -373,6 +374,7 @@
 				INFOPLIST_FILE = DemoApp/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 8.3;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "-.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = iphoneos;
 				VALIDATE_PRODUCT = YES;
@@ -398,6 +400,7 @@
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				COPY_PHASE_STRIP = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_DYNAMIC_NO_PIC = NO;
 				GCC_OPTIMIZATION_LEVEL = 0;
@@ -482,6 +485,7 @@
 				);
 				INFOPLIST_FILE = UnitTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "-.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 			};
 			name = Debug;
@@ -496,6 +500,7 @@
 				);
 				INFOPLIST_FILE = UnitTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "-.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 			};
 			name = Release;

--- a/ls2xs.xcodeproj/xcshareddata/xcschemes/ls2xs.xcscheme
+++ b/ls2xs.xcodeproj/xcshareddata/xcschemes/ls2xs.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0610"
+   LastUpgradeVersion = "0700"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -23,10 +23,10 @@
       </BuildActionEntries>
    </BuildAction>
    <TestAction
+      buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      shouldUseLaunchSchemeArgsEnv = "YES"
-      buildConfiguration = "Debug">
+      shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
          <TestableReference
             skipped = "NO">
@@ -48,17 +48,21 @@
             ReferencedContainer = "container:ls2xs.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
    </TestAction>
    <LaunchAction
+      buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
-      buildConfiguration = "Debug"
       ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
       allowLocationSimulation = "YES">
-      <BuildableProductRunnable>
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "7F9ABCD31A88E79100ACB4B9"
@@ -77,12 +81,13 @@
       </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
+      buildConfiguration = "Release"
       shouldUseLaunchSchemeArgsEnv = "YES"
       savedToolIdentifier = ""
       useCustomWorkingDirectory = "NO"
-      buildConfiguration = "Release"
       debugDocumentVersioning = "YES">
-      <BuildableProductRunnable>
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "7F9ABCD31A88E79100ACB4B9"

--- a/ls2xs.xcodeproj/xcshareddata/xcschemes/ls2xs.xcscheme
+++ b/ls2xs.xcodeproj/xcshareddata/xcschemes/ls2xs.xcscheme
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
    LastUpgradeVersion = "0700"
-   version = "1.3">
+   version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"
       buildImplicitDependencies = "YES">
@@ -37,6 +37,10 @@
                BlueprintName = "UnitTests"
                ReferencedContainer = "container:ls2xs.xcodeproj">
             </BuildableReference>
+            <LocationScenarioReference
+               identifier = "com.apple.dt.IDEFoundation.CurrentLocationScenarioIdentifier"
+               referenceType = "1">
+            </LocationScenarioReference>
          </TestableReference>
       </Testables>
       <MacroExpansion>
@@ -77,6 +81,13 @@
             isEnabled = "YES">
          </CommandLineArgument>
       </CommandLineArguments>
+      <EnvironmentVariables>
+         <EnvironmentVariable
+            key = "MY_SOURCE_ROOT"
+            value = "$(SOURCE_ROOT)"
+            isEnabled = "YES">
+         </EnvironmentVariable>
+      </EnvironmentVariables>
       <AdditionalOptions>
       </AdditionalOptions>
    </LaunchAction>

--- a/ls2xs/LprojFile.swift
+++ b/ls2xs/LprojFile.swift
@@ -64,7 +64,7 @@ class LprojFile {
     
     func stringsFilesForXibNames(xibNames: [String]) -> [StringsFile] {
         return stringsFiles.filter(){ stringsFile in
-            contains(xibNames, stringsFile.URL.lastPathComponent!.stringByDeletingPathExtension)
+            xibNames.contains(stringsFile.URL.lastPathComponent!.stringByDeletingPathExtension)
         }
     }
 }

--- a/ls2xs/LprojFile.swift
+++ b/ls2xs/LprojFile.swift
@@ -55,7 +55,7 @@ class LprojFile {
     
     init?(URL: NSURL) {
         self.URL = URL
-        self.name = URL.lastPathComponent?.stringByDeletingPathExtension ?? ""
+        self.name = URL.URLByDeletingPathExtension?.lastPathComponent ?? ""
         
         if URL.pathExtension != "lproj" || self.name.isEmpty {
             return nil
@@ -64,7 +64,7 @@ class LprojFile {
     
     func stringsFilesForXibNames(xibNames: [String]) -> [StringsFile] {
         return stringsFiles.filter(){ stringsFile in
-            xibNames.contains(stringsFile.URL.lastPathComponent!.stringByDeletingPathExtension)
+            xibNames.contains((stringsFile.URL.URLByDeletingPathExtension?.lastPathComponent)!)
         }
     }
 }

--- a/ls2xs/NSFileManager.swift
+++ b/ls2xs/NSFileManager.swift
@@ -3,12 +3,9 @@ import Foundation
 extension NSFileManager {
     func fileURLsInURL(URL: NSURL) -> [NSURL] {
         let fileManager = NSFileManager.defaultManager()
-        let enumerator = fileManager.enumeratorAtURL(URL, includingPropertiesForKeys: [], options: .SkipsHiddenFiles) { URL, error in
-            if let error = error {
-                print("error: \(error)")
-                return false
-            }
-            return true
+        let enumerator = fileManager.enumeratorAtURL(URL, includingPropertiesForKeys: [], options: .SkipsHiddenFiles) { (URL: NSURL, error: NSError) in
+            print("error: \(error)")
+            return false
         }
 
         var URLs = [NSURL]()

--- a/ls2xs/NSFileManager.swift
+++ b/ls2xs/NSFileManager.swift
@@ -5,7 +5,7 @@ extension NSFileManager {
         let fileManager = NSFileManager.defaultManager()
         let enumerator = fileManager.enumeratorAtURL(URL, includingPropertiesForKeys: [], options: .SkipsHiddenFiles) { URL, error in
             if let error = error {
-                println("error: \(error)")
+                print("error: \(error)")
                 return false
             }
             return true

--- a/ls2xs/StringsFile.swift
+++ b/ls2xs/StringsFile.swift
@@ -7,7 +7,7 @@ class StringsFile {
     
     init?(URL: NSURL) {
         self.URL = URL
-        self.name = URL.lastPathComponent?.stringByDeletingPathExtension ?? ""
+        self.name = URL.URLByDeletingPathExtension?.lastPathComponent ?? ""
         self.dictionary = (NSDictionary(contentsOfURL: URL) as? [String: String]) ?? [String: String]()
         
         if URL.pathExtension != "strings" || self.name.isEmpty {

--- a/ls2xs/StringsFile.swift
+++ b/ls2xs/StringsFile.swift
@@ -27,7 +27,7 @@ class StringsFile {
         var string = ""
         
         for (key, value) in dictionary {
-            let escapedValue: String? = map(value) { character in
+            let escapedValue: String? = Optional(value).map { character in
                 switch character {
                 case "\"": return "\\n"
                 case "\r": return "\\r"
@@ -42,7 +42,10 @@ class StringsFile {
             }
         }
         
-        // TODO: handle error
-        string.writeToURL(URL, atomically: true, encoding: NSUTF8StringEncoding, error: nil)
+        do {
+            // TODO: handle error
+            try string.writeToURL(URL, atomically: true, encoding: NSUTF8StringEncoding)
+        } catch _ {
+        }
     }
 }

--- a/ls2xs/Target.swift
+++ b/ls2xs/Target.swift
@@ -27,8 +27,8 @@ class Target {
 
     init?(path: String) {
         let currentPath = NSFileManager.defaultManager().currentDirectoryPath
-        let inputPath = currentPath.stringByAppendingPathComponent(path)
-        URL = NSURL(fileURLWithPath: inputPath)
+        let inputPath = NSURL(string: currentPath)?.URLByAppendingPathComponent(path)
+        URL = inputPath
 
         if URL == nil {
             print("error: passed invalid path.")

--- a/ls2xs/Target.swift
+++ b/ls2xs/Target.swift
@@ -28,15 +28,15 @@ class Target {
     init?(path: String) {
         let currentPath = NSFileManager.defaultManager().currentDirectoryPath
         let inputPath = currentPath.stringByAppendingPathComponent(path)
-        URL = NSURL(fileURLWithPath: inputPath)!
+        URL = NSURL(fileURLWithPath: inputPath)
 
         if URL == nil {
-            println("error: passed invalid path.")
+            print("error: passed invalid path.")
             return nil
         }
 
         if baseLprojFile == nil {
-            println("error: could not find Base.lproj in \(URL.path!)")
+            print("error: could not find Base.lproj in \(URL.path!)")
             return nil
         }
     }
@@ -45,7 +45,7 @@ class Target {
         let xibNames = baseLprojFile.xibFiles.map({ $0.name })
         for xibFile in baseLprojFile.xibFiles {
             for lprojFile in langLprojFiles {
-                println("generating .strings for \(lprojFile.URL.path!)/\(xibFile.name).strings")
+                print("generating .strings for \(lprojFile.URL.path!)/\(xibFile.name).strings")
                 xibFile.generateStringsInLprojFile(lprojFile)
             }
         }
@@ -53,15 +53,15 @@ class Target {
         for lprojFile in langLprojFiles {
             if let localizableStringsFile = lprojFile.localizableStringsFile {
                 for stringsFile in lprojFile.stringsFilesForXibNames(xibNames) {
-                    println("updating \(stringsFile.URL.path!)")
+                    print("updating \(stringsFile.URL.path!)")
                     stringsFile.updateValuesUsingLocalizableStringsFile(localizableStringsFile)
                     stringsFile.save()
                 }
             } else {
-                println("warning: Localizable.strings is not found in \(lprojFile.URL.path!)")
+                print("warning: Localizable.strings is not found in \(lprojFile.URL.path!)")
             }
         }
 
-        println("done.")
+        print("done.")
     }
 }

--- a/ls2xs/XibFile.swift
+++ b/ls2xs/XibFile.swift
@@ -6,7 +6,7 @@ class XibFile {
     
     init?(URL: NSURL) {
         self.URL = URL
-        self.name = URL.lastPathComponent?.stringByDeletingPathExtension ?? ""
+        self.name = URL.URLByDeletingPathExtension?.lastPathComponent ?? ""
         
         if (URL.pathExtension != "xib" && URL.pathExtension != "storyboard") || self.name.isEmpty {
             return nil

--- a/ls2xs/main.swift
+++ b/ls2xs/main.swift
@@ -3,5 +3,5 @@ import Foundation
 if Process.arguments.count == 2 {
     Target(path: Process.arguments[1])?.run()
 } else {
-    println("usage: ls2xs <path>")
+    print("usage: ls2xs <path>")
 }


### PR DESCRIPTION
はじめまして。安宅と申します。

ls2xs のコンパイルが XCode 7 で通らなかったので、通るように修正しました。
Swift 1.2 のコードを Swift 2.0 に変更しただけです。

---
### 追記:

XCode 7 で `NSFileManager.defaultManager().currentDirectoryPath` がプロジェクトのあるディレクトリーではなく、ビルド・ディレクトリーを指すようになっていたので、テストを修正してあります。
